### PR TITLE
ffplaytool poetry fix

### DIFF
--- a/nulrdcscripts/tools/ffplaywindow/main.py
+++ b/nulrdcscripts/tools/ffplaywindow/main.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from scriptparser import args
+from nulrdcscripts.tools.ffplaywindow.scriptparser import args
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ aproc = 'nulrdcscripts.aproc.aproc:main'
 vproc = 'nulrdcscripts.vproc.vproc:main'
 ingest = 'nulrdcscripts.ingest.ingest:main'
 oyez = 'nulrdcscripts.tools.oyez:main'
-ffplaywindow = 'nulrdcscripts.tools.ffplaywindow:main'
+ffplaywindow = 'nulrdcscripts.tools.ffplaywindow.main:main'
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Fixed a few issues with paths. In the .toml file, the final ":main" refers to the main function, so you need one more ".main" to refer to the main.py file. Also, when importing from scriptparser.py, you need to use its path relative to where the .toml file is.